### PR TITLE
fix: make fail use correct attribute name

### DIFF
--- a/lib/analysis_test.bzl
+++ b/lib/analysis_test.bzl
@@ -55,7 +55,7 @@ def _fail(env, msg):
     # There isn't a better way to output the message in Starlark, so use print.
     # buildifier: disable=print
     print(full_msg)
-    env._failures.append(full_msg)
+    env.failures.append(full_msg)
 
 def _begin_analysis_test(ctx):
     """Begins a unit test.
@@ -91,6 +91,8 @@ def _begin_analysis_test(ctx):
     )
     analysis_test_env = struct(
         ctx = ctx,
+        # Visibility: package; only exposed so that our own tests can verify
+        # failure behavior.
         _failures = failures,
         fail = truth_env.fail,
         expect = truth.expect(truth_env),

--- a/tests/truth_tests.bzl
+++ b/tests/truth_tests.bzl
@@ -1260,6 +1260,37 @@ def _run_environment_info_subject_test(env, target):
 
 _suite.append(run_environment_info_subject_test)
 
+def _add_failure_works_test(name):
+    analysis_test(
+        name,
+        impl = _add_failure_works_test_impl,
+        target = "truth_tests_noop",
+        expect_failure = True,
+    )
+
+def _add_failure_works_test_impl(env, target):
+    """Test that the real add_failure() codepath works.
+
+    All the other tests mock out the fail() call, this is the one test that doesn't.
+    """
+
+    # NOTE: this prints a spurious message.
+    env.expect.meta.add_failure("FAKE PROBLEM", "FAKE ACTUAL")
+
+    failures = list(env._failures)
+    env._failures.clear()
+
+    if len(failures) != 1:
+        env.fail("Expected len(failures) == 1, got " + str(len(failures)))
+    else:
+        failure = failures[0]
+        if "FAKE PROBLEM" not in failure:
+            env.fail("Expected string 'FAKE PROBLEM' not found in failure message")
+        if "FAKE ACTUAL" not in failure:
+            env.fail("Expected string 'FAKE ACTUAL' not found in failure message")
+
+_suite.append(_add_failure_works_test)
+
 def _assert_no_failures(fake_env, *, env, msg = ""):
     fail_lines = [
         "expected no failures, but found failures",


### PR DESCRIPTION
The prior change incorrectly made `_fail` look for the `env._failures` attribute, when it is actually called `env.failures`

This went unnoticed because all the tests mock out the fail call (if they didn't, then tests checking for expected failures would fail).

To work around this, add a test that calls the real failure function to exercise the real code path. The test clears the list of failures prior to the test finishing to prevent the expected failure from failing the entire test.